### PR TITLE
Add kubernetes EFK stack manifest

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "kubernetes-efk"]
+	path = kubernetes-efk
+	url = https://github.com/ast9501/kubernetes-efk.git

--- a/EFK/README.md
+++ b/EFK/README.md
@@ -64,3 +64,6 @@ edit password env parameter
 ```
 kubectl apply -f fluentd/
 ```
+
+### Support
+https://devopscube.com/setup-efk-stack-on-kubernetes/

--- a/EFK/README.md
+++ b/EFK/README.md
@@ -1,0 +1,66 @@
+# Deploy EFK on Kubernetes
+## Prerequirement
+Configure nfs-provisioner well
+
+## Deploy elasticsearch
+### Install CR
+```
+kubectl create -f https://download.elastic.co/downloads/eck/2.6.1/crds.yaml
+```
+
+### Install operator
+```
+kubectl apply -f https://download.elastic.co/downloads/eck/2.6.1/operator.yaml
+```
+
+### Deploy an elastic cluster
+* Create CustomResource
+Deploy CR, nameing `main`, in monitor namespace:
+```
+cd elasticsearch
+k apply -f cr.yaml
+```
+* Get status
+```
+kubectl get elasticsearch
+```
+the `HEALTH` will be green
+
+### Access Elasticsearch
+* Grant Password
+```
+PASSWORD=$(kubectl get secret -n monitor main-es-elastic-user -o go-template='{{.data.elastic | base64decode}}')
+```
+* Port-forward
+```
+kubectl port-forward -n monitor service/main-es-http 9200
+curl -u "elastic:$PASSWORD" -k "https://localhost:9200"
+```
+
+### Support
+https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-deploy-elasticsearch.html
+
+
+## Install kibana
+* Create CR
+```
+cd kibana
+k apply -f cr.yaml
+```
+### Access kibana
+* Grant Password
+```
+kubectl get secret -n monitor main-es-elastic-user -o=jsonpath='{.data.elastic}' | base64 --decode; echo
+```
+
+## Install fluentd
+>Under testing
+* Modify `fluentd/fluent-ds.yaml`
+```
+edit password env parameter
+```
+
+* Apply
+```
+kubectl apply -f fluentd/
+```

--- a/EFK/elasticsearch/cr.yaml
+++ b/EFK/elasticsearch/cr.yaml
@@ -1,0 +1,29 @@
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  name: main
+  namespace: monitor
+spec:
+  version: 8.6.1 #7.6.2
+  #transport:
+  #  service:
+  #    metadata:
+  #      labels:
+  #        app: elasticsearch
+  #    spec:
+  #      type: NodePort
+  nodeSets:
+  - name: default
+    count: 1
+    config:
+      node.store.allow_mmap: false
+    volumeClaimTemplates:
+    - metadata:
+        name: elasticsearch-data # Do not change this name unless you set up a volume mount for the data path.
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 5Gi
+        storageClassName: nfs-client

--- a/EFK/fluentd/fluentd-ds.yaml
+++ b/EFK/fluentd/fluentd-ds.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: fluentd
+  namespace: monitor
+  labels:
+    app: fluentd
+spec:
+  selector:
+    matchLabels:
+      app: fluentd
+  template:
+    metadata:
+      labels:
+        app: fluentd
+    spec:
+      serviceAccount: fluentd
+      serviceAccountName: fluentd
+      containers:
+      - name: fluentd
+        image: fluent/fluentd-kubernetes-daemonset:v1.15-debian-elasticsearch7-1
+        env:
+          - name:  FLUENT_ELASTICSEARCH_HOST
+            value: "main-es-http.monitor.svc.cluster.local"
+          - name:  FLUENT_ELASTICSEARCH_PORT
+            value: "9200"
+          - name: FLUENT_ELASTICSEARCH_USER
+            value: "elastic"
+          - name: FLUENT_ELASTICSEARCH_PASSWORD
+            value: "5ESn008yZZP8Z2Hv07JXWC06" # fill in passwd
+          - name: FLUENT_ELASTICSEARCH_SCHEME
+            value: "https"
+          - name: FLUENT_ELASTICSEARCH_SSL_VERIFY
+            value: "false"
+          - name: FLUENTD_SYSTEMD_CONF
+            value: disable
+        resources:
+          limits:
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        volumeMounts:
+        - name: varlog
+          mountPath: /var/log
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers

--- a/EFK/fluentd/fluentd-rb.yaml
+++ b/EFK/fluentd/fluentd-rb.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: fluentd
+roleRef:
+  kind: ClusterRole
+  name: fluentd
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: fluentd
+  namespace: monitor

--- a/EFK/fluentd/fluentd-role.yaml
+++ b/EFK/fluentd/fluentd-role.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: fluentd
+  labels:
+    app: fluentd
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch

--- a/EFK/fluentd/fluentd-sa.yaml
+++ b/EFK/fluentd/fluentd-sa.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fluentd
+  namespace: monitor
+  labels:
+    app: fluentd

--- a/EFK/kibana/cr.yaml
+++ b/EFK/kibana/cr.yaml
@@ -1,0 +1,11 @@
+apiVersion: kibana.k8s.elastic.co/v1
+kind: Kibana
+metadata:
+  name: main
+  namespace: monitor
+spec:
+  version: 8.6.1
+  count: 1
+  elasticsearchRef:
+    name: main
+    namespace: monitor

--- a/EFK/test-pod.yaml
+++ b/EFK/test-pod.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: counter
+spec:
+  containers:
+  - name: count
+    image: busybox
+    args: [/bin/sh, -c,'i=0; while true; do echo "Thanks for visiting devopscube! $i"; i=$((i+1)); sleep 1; done']


### PR DESCRIPTION
Add Kubernetes EFK manifest inspired by [this](https://github.com/scriptcamp/kubernetes-efk) project:
- Elasticsearch v7.5.0 (reuse, row YAML)
- Kibana v7.5.0(reuse, row YAML)
- Fluent bit v2.0.8 (new create, modified public helm chart)

Check list:
- [x] README file
    - [x] Environment
    - [x] Guide
    - [x] Support
- [x] Test on clean environment